### PR TITLE
OS X build instructions & CMake adjustments

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ include_directories(
     ${SDL2MIXER_INCLUDE_DIRS}
 )
 
-if(CMAKE_COMPILER_IS_GNUCXX)
+if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -pedantic -std=c++11 -O")
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,12 +1,32 @@
 project(freegemas_project)
 cmake_minimum_required(VERSION 2.6)
 
-INCLUDE(FindPkgConfig)
+include(FindPkgConfig)
 
-PKG_SEARCH_MODULE(SDL2 REQUIRED sdl2)
-PKG_SEARCH_MODULE(SDL2IMAGE REQUIRED SDL2_image>=2.0.0)
-PKG_SEARCH_MODULE(SDL2TTF REQUIRED SDL2_ttf>=2.0.0)
-PKG_SEARCH_MODULE(SDL2MIXER REQUIRED SDL2_mixer>=2.0.0)
+pkg_search_module(SDL2 REQUIRED sdl2)
+pkg_search_module(SDL2IMAGE REQUIRED SDL2_image>=2.0.0)
+pkg_search_module(SDL2TTF REQUIRED SDL2_ttf>=2.0.0)
+pkg_search_module(SDL2MIXER REQUIRED SDL2_mixer>=2.0.0)
+
+# Append custom gettext path to CMAKE_PREFIX_PATH - only necessary on OS X.
+if (CMAKE_HOST_APPLE)
+    find_program(HOMEBREW_PROG brew)
+    if (EXISTS ${HOMEBREW_PROG})
+        execute_process(COMMAND ${HOMEBREW_PROG} --prefix gettext
+            OUTPUT_STRIP_TRAILING_WHITESPACE
+            OUTPUT_VARIABLE HOMEBREW_GETTEXT_PREFIX)
+        list(APPEND CMAKE_PREFIX_PATH "${HOMEBREW_GETTEXT_PREFIX}")
+    endif()
+
+    find_path(LIBINTL_INCLUDE_DIRS
+        NAMES libintl.h
+        PATH_SUFFIXES gettext
+    )
+
+    find_library(LIBINTL_LIBRARIES
+        NAMES intl libintl.a
+    )
+endif()
 
 include_directories(
     ${PROJECT_SOURCE_DIR}/include
@@ -15,6 +35,7 @@ include_directories(
     ${SDL2IMAGE_INCLUDE_DIRS}
     ${SDL2TTF_INCLUDE_DIRS}
     ${SDL2MIXER_INCLUDE_DIRS}
+    ${LIBINTL_INCLUDE_DIRS}
 )
 
 if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
@@ -36,6 +57,7 @@ target_link_libraries(freegemas
   ${SDL2IMAGE_LIBRARIES}
   ${SDL2TTF_LIBRARIES}
   ${SDL2MIXER_LIBRARIES}
+  ${LIBINTL_LIBRARIES}
 )
 
 add_custom_target(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,7 +40,7 @@ target_link_libraries(freegemas
 
 add_custom_target(
   link_media_folder
-  COMMAND ln -s ${PROJECT_SOURCE_DIR}/media ${PROJECT_BINARY_DIR}/media
+  COMMAND ln -nfs ${PROJECT_SOURCE_DIR}/media ${PROJECT_BINARY_DIR}/media
 )
 
 add_dependencies(

--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ __Freegemas__ is an open source version of the well known Bejeweled, for GNU/Lin
         
 
 
-## Installing
+## Installation on Debian-based GNU/Linux systems
 
-These instructions are for debian-based GNU/Linux systems. First, you need to install git and gcc:
+First, you need to install git and gcc:
 
     sudo apt-get install git build-essential cmake
 
@@ -32,8 +32,16 @@ Do an out-of-source compilation and run the program:
     cmake ..
     make
     ./freegemas
-    
-    
+
+## Installation on OS X
+
+This assumes that you are already using [Homebrew](http://brew.sh/). You will need CMake and a few libraries to compile Freegemas:
+
+    brew install cmake sdl2 sdl2_mixer sdl2_ttf sdl2_image gettext
+
+Now follow the instructions above, starting with `git clone`.
+
 ## Music licensing
+
 The music in the game is [Easy Lemon by Kevin MacLeod](http://incompetech.com/music/royalty-free/index.html?isrc=USUAN1200076)
 Licensed under [Creative Commons: By Attribution 3.0](http://creativecommons.org/licenses/by/3.0/)


### PR DESCRIPTION
I've added installation instructions for OS X, and some CMake adjustments that hopefully won't hurt on other systems.

Specifically, OS X does not ship with `libintl.h`, and Homebrew does not install it into `/usr/include/` by default, so the `CMakeLists.txt` needed some more elaborate finder magic. (The cleaner solution would be to find a sane FindLibIntl.cmake on the internet, but I didn't want to include any of them because I suck at licenses...)

OS X also uses clang instead of gcc, but the command line for C++11 support is the same, so this was an easy fix.

Tested on OS X Yosemite 10.10 and Ubuntu 15.04.