### PR TITLE
Fix endless mode high load

### DIFF
--- a/include/GameBoard.h
+++ b/include/GameBoard.h
@@ -32,8 +32,6 @@ public:
 
     void showHint();
 
-    bool hasSolution();
-
 private:
 
     /// Tests if the mouse is over a gem

--- a/include/StateGame.h
+++ b/include/StateGame.h
@@ -75,6 +75,8 @@ public:
     void mouseButtonDown(Uint8 button);
     void mouseButtonUp(Uint8 button);
 
+    int getScore();
+
 protected:
     friend class GameIndicators;
     friend class GameBoard;
@@ -114,7 +116,6 @@ private:
 
     // Increases the score by the given amount
     void increaseScore (int amount);
-
 
     /// Shows a hint for a possible match
     void showHint();

--- a/src/GameBoard.cpp
+++ b/src/GameBoard.cpp
@@ -204,7 +204,7 @@ void GameBoard::update()
             }
 
             // If there are neither current solutions nor possible future solutions
-            else if (!mBoard.solutions().empty())
+            else if (mBoard.solutions().empty())
             {
                 // Make the board disappear
                 mState = eBoardDisappearing;
@@ -660,7 +660,5 @@ bool GameBoard::checkSelectedSquare() {
 }
 
 bool GameBoard::hasSolution() {
-    if (mState != eGemDisappearing)
-        return true;
-    return false;
+    return mState != eBoardDisappearing;
 }

--- a/src/GameBoard.cpp
+++ b/src/GameBoard.cpp
@@ -206,11 +206,15 @@ void GameBoard::update()
             // If there are neither current solutions nor possible future solutions
             else if (mBoard.solutions().empty())
             {
-                // Make the board disappear
-                mState = eBoardDisappearing;
+                if (mGame->getCurrentState() == "stateGameEndless") {
+                    endGame(mStateGame->getScore());
+                } else {
+                    // Make the board disappear
+                    mState = eBoardDisappearing;
 
-                // Make all the gems want to go outside the board
-                mBoard.dropAllGems();
+                    // Make all the gems want to go outside the board
+                    mBoard.dropAllGems();
+                }
             }
         }
     }
@@ -657,8 +661,4 @@ bool GameBoard::checkSelectedSquare() {
     }
 
     return false;
-}
-
-bool GameBoard::hasSolution() {
-    return mState != eBoardDisappearing;
 }

--- a/src/GameBoard.cpp
+++ b/src/GameBoard.cpp
@@ -204,7 +204,7 @@ void GameBoard::update()
             }
 
             // If there are neither current solutions nor possible future solutions
-            else if (!hasSolution())
+            else if (!mBoard.solutions().empty())
             {
                 // Make the board disappear
                 mState = eBoardDisappearing;
@@ -660,5 +660,7 @@ bool GameBoard::checkSelectedSquare() {
 }
 
 bool GameBoard::hasSolution() {
-    return !mBoard.solutions().empty();
+    if (mState != eGemDisappearing)
+        return true;
+    return false;
 }

--- a/src/StateGame.cpp
+++ b/src/StateGame.cpp
@@ -161,3 +161,6 @@ void StateGame::increaseScore (int amount)
     mGameIndicators.increaseScore(amount);
 }
 
+int StateGame::getScore() {
+    return mGameIndicators.getScore();
+}

--- a/src/StateGameEndless.cpp
+++ b/src/StateGameEndless.cpp
@@ -26,8 +26,5 @@ void StateGameEndless::update()
         mGameIndicators.setScore(0);
     }
 
-    if (!mGameBoard.hasSolution()) {
-        mGameBoard.endGame(mGameIndicators.getScore());
-    }
     mGameBoard.update();
 }


### PR DESCRIPTION
This fixes #6. Instead of calculating to see if there are solutions on every frame, this now checks if the game is in the state which is set when that is the case.