### PR TITLE
Add basic game controller support

### DIFF
--- a/include/Game.h
+++ b/include/Game.h
@@ -26,6 +26,8 @@ public:
     void mouseButtonDown(Uint8 button);
     void mouseButtonUp(Uint8 button);
 
+    void joystickEvent(SDL_Event event);
+
     void changeState(std::string S);
 
     std::string getCurrentState();

--- a/include/Game.h
+++ b/include/Game.h
@@ -25,8 +25,7 @@ public:
     void buttonUp(SDL_Keycode button);
     void mouseButtonDown(Uint8 button);
     void mouseButtonUp(Uint8 button);
-
-    void joystickEvent(SDL_Event event);
+    void controllerButtonDown(Uint8 button);
 
     void changeState(std::string S);
 

--- a/include/GameBoard.h
+++ b/include/GameBoard.h
@@ -29,8 +29,7 @@ public:
     void mouseButtonDown(int, int);
     void mouseButtonUp(int, int);
     void buttonDown(SDL_Keycode button);
-
-    void joystickEvent(SDL_Event event);
+    void controllerButtonDown(Uint8 button);
 
     void showHint();
 

--- a/include/GameBoard.h
+++ b/include/GameBoard.h
@@ -30,6 +30,8 @@ public:
     void mouseButtonUp(int, int);
     void buttonDown(SDL_Keycode button);
 
+    void joystickEvent(SDL_Event event);
+
     void showHint();
 
 private:

--- a/include/State.h
+++ b/include/State.h
@@ -53,6 +53,9 @@ public:
 
     virtual void mouseButtonUp(Uint8) { }
 
+    virtual void joystickEvent(SDL_Event event) { }
+
+
     /// Default destructor
     virtual ~State();
 };

--- a/include/State.h
+++ b/include/State.h
@@ -53,7 +53,7 @@ public:
 
     virtual void mouseButtonUp(Uint8) { }
 
-    virtual void joystickEvent(SDL_Event event) { }
+    virtual void controllerButtonDown(Uint8 button) { }
 
 
     /// Default destructor

--- a/include/StateGame.h
+++ b/include/StateGame.h
@@ -75,7 +75,7 @@ public:
     void mouseButtonDown(Uint8 button);
     void mouseButtonUp(Uint8 button);
 
-    void joystickEvent(SDL_Event event);
+    void controllerButtonDown(Uint8 button);
 
     int getScore();
 

--- a/include/StateGame.h
+++ b/include/StateGame.h
@@ -75,6 +75,8 @@ public:
     void mouseButtonDown(Uint8 button);
     void mouseButtonUp(Uint8 button);
 
+    void joystickEvent(SDL_Event event);
+
     int getScore();
 
 protected:

--- a/include/StateHowToPlay.h
+++ b/include/StateHowToPlay.h
@@ -20,7 +20,7 @@ public:
     void buttonDown (SDL_Keycode button);
     void mouseButtonDown (Uint8 button);
 
-    void joystickEvent(SDL_Event event);
+    void controllerButtonDown(Uint8 button);
 
     ~StateHowtoplay();
 

--- a/include/StateHowToPlay.h
+++ b/include/StateHowToPlay.h
@@ -20,6 +20,8 @@ public:
     void buttonDown (SDL_Keycode button);
     void mouseButtonDown (Uint8 button);
 
+    void joystickEvent(SDL_Event event);
+
     ~StateHowtoplay();
 
 private:

--- a/include/StateMainMenu.h
+++ b/include/StateMainMenu.h
@@ -51,7 +51,7 @@ public:
 
     void mouseButtonDown(Uint8 button);
 
-    void joystickEvent(SDL_Event event);
+    void controllerButtonDown(Uint8 button);
 
     ~StateMainMenu();
 

--- a/include/StateMainMenu.h
+++ b/include/StateMainMenu.h
@@ -51,6 +51,8 @@ public:
 
     void mouseButtonDown(Uint8 button);
 
+    void joystickEvent(SDL_Event event);
+
     ~StateMainMenu();
 
 private:
@@ -98,6 +100,9 @@ private:
     /// It gets executed when the user choses an option. It changes the state
     ///  to the proper one.
     void optionChosen();
+
+    void moveUp();
+    void moveDown();
 
     /// @{
     /// @name Coordinates of the menu elements

--- a/include/go_window.h
+++ b/include/go_window.h
@@ -86,7 +86,7 @@ namespace GoSDL {
 
         /**
          * @brief Event for the game controller button press events
-         * @details It receives the released game controller button
+         * @details It receives the pressed game controller button
          */
         virtual void controllerButtonDown(Uint8 button) { }
 

--- a/include/go_window.h
+++ b/include/go_window.h
@@ -85,7 +85,7 @@ namespace GoSDL {
         virtual void mouseButtonUp(Uint8) { }
 
         /**
-         * @brief Event for the game controller button release events
+         * @brief Event for the game controller button press events
          * @details It receives the released game controller button
          */
         virtual void controllerButtonDown(Uint8 button) { }

--- a/include/go_window.h
+++ b/include/go_window.h
@@ -85,6 +85,12 @@ namespace GoSDL {
         virtual void mouseButtonUp(Uint8) { }
 
         /**
+         * @brief Event for the mouse button release events
+         * @details It receives the released mouse button
+         */
+        virtual void joystickEvent(SDL_Event event) { }
+
+        /**
          * @brief Returns the horizontal position of the mouse
          */
         int getMouseX();
@@ -131,6 +137,8 @@ namespace GoSDL {
 
         /// Ticks recorded in last frame
         Uint32 mLastTicks;
+
+        SDL_Joystick *joystick = NULL;
 
         /// Main rendering window
         SDL_Window * mWindow = NULL;

--- a/include/go_window.h
+++ b/include/go_window.h
@@ -85,10 +85,10 @@ namespace GoSDL {
         virtual void mouseButtonUp(Uint8) { }
 
         /**
-         * @brief Event for the mouse button release events
-         * @details It receives the released mouse button
+         * @brief Event for the game controller button release events
+         * @details It receives the released game controller button
          */
-        virtual void joystickEvent(SDL_Event event) { }
+        virtual void controllerButtonDown(Uint8 button) { }
 
         /**
          * @brief Returns the horizontal position of the mouse
@@ -138,7 +138,7 @@ namespace GoSDL {
         /// Ticks recorded in last frame
         Uint32 mLastTicks;
 
-        SDL_Joystick *joystick = NULL;
+        SDL_GameController *gameController = NULL;
 
         /// Main rendering window
         SDL_Window * mWindow = NULL;

--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -63,10 +63,10 @@ void Game::mouseButtonUp (Uint8 button)
         mCurrentState -> mouseButtonUp(button);
 }
 
-void Game::joystickEvent (SDL_Event event)
+void Game::controllerButtonDown (Uint8 button)
 {
     if (mCurrentState)
-        mCurrentState -> joystickEvent(event);
+        mCurrentState -> controllerButtonDown(button);
 }
 
 void Game::changeState(string S)

--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -63,6 +63,12 @@ void Game::mouseButtonUp (Uint8 button)
         mCurrentState -> mouseButtonUp(button);
 }
 
+void Game::joystickEvent (SDL_Event event)
+{
+    if (mCurrentState)
+        mCurrentState -> joystickEvent(event);
+}
+
 void Game::changeState(string S)
 {
     if(S == mCurrentStateString)

--- a/src/GameBoard.cpp
+++ b/src/GameBoard.cpp
@@ -484,7 +484,8 @@ void GameBoard::moveSelector(int x, int y) {
     }
 }
 
-void GameBoard::buttonDown(SDL_Keycode button) {
+void GameBoard::buttonDown(SDL_Keycode button)
+{
     switch(button) {
     case SDLK_LEFT:
         mMouseActive = false;
@@ -509,6 +510,51 @@ void GameBoard::buttonDown(SDL_Keycode button) {
     case SDLK_SPACE:
         selectGem();
         break;
+    }
+}
+
+void GameBoard::joystickEvent(SDL_Event event)
+{
+    switch (event.type)
+    {
+        case SDL_JOYHATMOTION:
+            if (event.jhat.value != SDL_HAT_CENTERED) {
+                mMouseActive = false;
+                mGameBoardSounds.playSoundSelect();
+            }
+            switch(event.jhat.value)
+            {
+                case SDL_HAT_LEFT:
+                    moveSelector(-1, 0);
+                    break;
+
+                case SDL_HAT_RIGHT:
+                    moveSelector(1, 0);
+                    break;
+                case SDL_HAT_UP:
+                    moveSelector(0, -1);
+                    break;
+
+                case SDL_HAT_DOWN:
+                    moveSelector(0, 1);
+                    break;
+            }
+            break;
+
+        case SDL_JOYBUTTONDOWN:
+            switch (event.jbutton.button)
+            {
+                case 0:
+                    selectGem();
+                    break;
+                case 3:
+                    showHint();
+                    break;
+                case 6:
+                    resetGame();
+                    break;
+            }
+            break;   
     }
 }
 

--- a/src/GameBoard.cpp
+++ b/src/GameBoard.cpp
@@ -548,10 +548,6 @@ void GameBoard::controllerButtonDown(Uint8 button)
             mGameBoardSounds.playSoundSelect();
             moveSelector(1, 0);
             break;
-
-        case SDL_CONTROLLER_BUTTON_BACK:
-            resetGame();
-            break;
     }
 }
 

--- a/src/GameBoard.cpp
+++ b/src/GameBoard.cpp
@@ -513,48 +513,45 @@ void GameBoard::buttonDown(SDL_Keycode button)
     }
 }
 
-void GameBoard::joystickEvent(SDL_Event event)
+void GameBoard::controllerButtonDown(Uint8 button)
 {
-    switch (event.type)
+    switch (button)
     {
-        case SDL_JOYHATMOTION:
-            if (event.jhat.value != SDL_HAT_CENTERED) {
-                mMouseActive = false;
-                mGameBoardSounds.playSoundSelect();
-            }
-            switch(event.jhat.value)
-            {
-                case SDL_HAT_LEFT:
-                    moveSelector(-1, 0);
-                    break;
-
-                case SDL_HAT_RIGHT:
-                    moveSelector(1, 0);
-                    break;
-                case SDL_HAT_UP:
-                    moveSelector(0, -1);
-                    break;
-
-                case SDL_HAT_DOWN:
-                    moveSelector(0, 1);
-                    break;
-            }
+        case SDL_CONTROLLER_BUTTON_Y:
+            showHint();
             break;
 
-        case SDL_JOYBUTTONDOWN:
-            switch (event.jbutton.button)
-            {
-                case 0:
-                    selectGem();
-                    break;
-                case 3:
-                    showHint();
-                    break;
-                case 6:
-                    resetGame();
-                    break;
-            }
-            break;   
+        case SDL_CONTROLLER_BUTTON_A:
+            selectGem();
+            break;
+
+        case SDL_CONTROLLER_BUTTON_DPAD_DOWN:
+            mMouseActive = false;
+            mGameBoardSounds.playSoundSelect();
+            moveSelector(0, 1);
+            break;
+
+        case SDL_CONTROLLER_BUTTON_DPAD_LEFT:
+            mMouseActive = false;
+            mGameBoardSounds.playSoundSelect();
+            moveSelector(-1, 0);
+            break;
+
+        case SDL_CONTROLLER_BUTTON_DPAD_UP:
+            mMouseActive = false;
+            mGameBoardSounds.playSoundSelect();
+            moveSelector(0, -1);
+            break;
+
+        case SDL_CONTROLLER_BUTTON_DPAD_RIGHT:
+            mMouseActive = false;
+            mGameBoardSounds.playSoundSelect();
+            moveSelector(1, 0);
+            break;
+
+        case SDL_CONTROLLER_BUTTON_BACK:
+            resetGame();
+            break;
     }
 }
 

--- a/src/StateGame.cpp
+++ b/src/StateGame.cpp
@@ -68,6 +68,8 @@ void StateGame::controllerButtonDown(Uint8 button)
 {
     if (button == SDL_CONTROLLER_BUTTON_START) {
         mGame -> changeState("stateMainMenu");
+    } else if (button == SDL_CONTROLLER_BUTTON_BACK) {
+        resetGame();
     } else {
         mGameBoard.controllerButtonDown(button);
     }

--- a/src/StateGame.cpp
+++ b/src/StateGame.cpp
@@ -64,6 +64,15 @@ void StateGame::buttonDown(SDL_Keycode button)
     }
 }
 
+void StateGame::joystickEvent(SDL_Event event)
+{
+    if (event.type == SDL_JOYBUTTONDOWN && event.jbutton.button == 7) {
+        mGame -> changeState("stateMainMenu");
+    } else {
+        mGameBoard.joystickEvent(event);
+    }
+}
+
 void StateGame::mouseButtonDown(Uint8 button)
 {
     // Left mouse button was pressed

--- a/src/StateGame.cpp
+++ b/src/StateGame.cpp
@@ -64,12 +64,12 @@ void StateGame::buttonDown(SDL_Keycode button)
     }
 }
 
-void StateGame::joystickEvent(SDL_Event event)
+void StateGame::controllerButtonDown(Uint8 button)
 {
-    if (event.type == SDL_JOYBUTTONDOWN && event.jbutton.button == 7) {
+    if (button == SDL_CONTROLLER_BUTTON_START) {
         mGame -> changeState("stateMainMenu");
     } else {
-        mGameBoard.joystickEvent(event);
+        mGameBoard.controllerButtonDown(button);
     }
 }
 

--- a/src/StateHowtoplay.cpp
+++ b/src/StateHowtoplay.cpp
@@ -71,12 +71,9 @@ void StateHowtoplay::buttonDown(SDL_Keycode button)
     }
 }
 
-void StateHowtoplay::joystickEvent(SDL_Event event)
+void StateHowtoplay::controllerButtonDown(Uint8 button)
 {
-    if (event.type == SDL_JOYBUTTONDOWN)
-    {
-        mGame -> changeState("stateMainMenu");
-    }
+    mGame -> changeState("stateMainMenu");
 }
 
 void StateHowtoplay::mouseButtonDown(Uint8 button)

--- a/src/StateHowtoplay.cpp
+++ b/src/StateHowtoplay.cpp
@@ -71,6 +71,14 @@ void StateHowtoplay::buttonDown(SDL_Keycode button)
     }
 }
 
+void StateHowtoplay::joystickEvent(SDL_Event event)
+{
+    if (event.type == SDL_JOYBUTTONDOWN)
+    {
+        mGame -> changeState("stateMainMenu");
+    }
+}
+
 void StateHowtoplay::mouseButtonDown(Uint8 button)
 {
     if (button == SDL_BUTTON_LEFT)

--- a/src/StateMainMenu.cpp
+++ b/src/StateMainMenu.cpp
@@ -139,17 +139,48 @@ void StateMainMenu::buttonDown(SDL_Keycode button)
             break;
 
         case SDLK_DOWN:
-            mMenuSelectedOption = (mMenuSelectedOption + 1) % mMenuTargets.size();
+            moveDown();
             break;
 
         case SDLK_UP:
-            mMenuSelectedOption = (mMenuSelectedOption - 1) % mMenuTargets.size();
+            moveUp();
             break;
 
         case SDLK_RETURN:
         case SDLK_KP_ENTER:
             optionChosen();
             break;
+    }
+}
+
+void StateMainMenu::joystickEvent(SDL_Event event)
+{
+    switch (event.type)
+    {
+        case SDL_JOYHATMOTION:
+            switch(event.jhat.value)
+            {
+                case SDL_HAT_UP:
+                    moveUp();
+                    break;
+
+                case SDL_HAT_DOWN:
+                    moveDown();
+                    break;
+            }
+            break;
+
+        case SDL_JOYBUTTONDOWN:
+            switch (event.jbutton.button)
+            {
+                case 0:
+                    optionChosen();
+                    break;
+      
+                default:
+                    printf("%i\n", event.jbutton.button);
+            }
+            break;   
     }
 }
 
@@ -166,6 +197,14 @@ void StateMainMenu::mouseButtonDown(Uint8 button)
             optionChosen();
         }
     }
+}
+
+void StateMainMenu::moveUp() {
+    mMenuSelectedOption = (mMenuSelectedOption - 1) % mMenuTargets.size();
+}
+
+void StateMainMenu::moveDown() {
+    mMenuSelectedOption = (mMenuSelectedOption + 1) % mMenuTargets.size();
 }
 
 void StateMainMenu::optionChosen()

--- a/src/StateMainMenu.cpp
+++ b/src/StateMainMenu.cpp
@@ -153,34 +153,21 @@ void StateMainMenu::buttonDown(SDL_Keycode button)
     }
 }
 
-void StateMainMenu::joystickEvent(SDL_Event event)
+void StateMainMenu::controllerButtonDown(Uint8 button)
 {
-    switch (event.type)
+    switch (button)
     {
-        case SDL_JOYHATMOTION:
-            switch(event.jhat.value)
-            {
-                case SDL_HAT_UP:
-                    moveUp();
-                    break;
-
-                case SDL_HAT_DOWN:
-                    moveDown();
-                    break;
-            }
+        case SDL_CONTROLLER_BUTTON_A:
+            optionChosen();
             break;
 
-        case SDL_JOYBUTTONDOWN:
-            switch (event.jbutton.button)
-            {
-                case 0:
-                    optionChosen();
-                    break;
-      
-                default:
-                    printf("%i\n", event.jbutton.button);
-            }
-            break;   
+        case SDL_CONTROLLER_BUTTON_DPAD_DOWN:
+            moveDown();
+            break;
+
+        case SDL_CONTROLLER_BUTTON_DPAD_UP:
+            moveUp();
+            break;
     }
 }
 

--- a/src/go_window.cpp
+++ b/src/go_window.cpp
@@ -13,7 +13,7 @@ GoSDL::Window::Window (unsigned width, unsigned height, std::string caption, boo
     mLastTicks = SDL_GetTicks();
 
     // Init SDL
-    if (SDL_Init(SDL_INIT_VIDEO | SDL_INIT_AUDIO | SDL_INIT_JOYSTICK) < 0)
+    if (SDL_Init(SDL_INIT_VIDEO | SDL_INIT_AUDIO | SDL_INIT_GAMECONTROLLER) < 0)
     {
         throw std::runtime_error(SDL_GetError());
     }
@@ -62,10 +62,15 @@ GoSDL::Window::Window (unsigned width, unsigned height, std::string caption, boo
         throw std::runtime_error(IMG_GetError() );
     }
 
-    // Initialize joystick
-    if( SDL_NumJoysticks() > 0 )
+    // Initialize game controllers
+    for (int i = 0; i < SDL_NumJoysticks(); ++i)
     {
-        joystick = SDL_JoystickOpen(0);
+        if (SDL_IsGameController(i)) {
+            gameController = SDL_GameControllerOpen(i);
+            if (gameController != NULL) {
+                break;
+            }
+        }
     }
 }
 
@@ -77,8 +82,8 @@ GoSDL::Window::~Window()
 	mWindow = NULL;
 
     // Close joystick
-    SDL_JoystickClose(joystick);
-    joystick = NULL;
+    SDL_GameControllerClose(gameController);
+    gameController = NULL;
 
 	// Quit SDL subsystems
 	Mix_Quit();
@@ -138,11 +143,8 @@ void GoSDL::Window::show()
                 mouseButtonUp(e.button.button);
                 break;
 
-            case SDL_JOYBUTTONDOWN:
-            case SDL_JOYBUTTONUP:
-            case SDL_JOYAXISMOTION:
-            case SDL_JOYHATMOTION:
-                joystickEvent(e);
+            case SDL_CONTROLLERBUTTONDOWN:
+                controllerButtonDown(e.cbutton.button);
                 break;
             }
         }

--- a/src/go_window.cpp
+++ b/src/go_window.cpp
@@ -62,7 +62,7 @@ GoSDL::Window::Window (unsigned width, unsigned height, std::string caption, boo
         throw std::runtime_error(IMG_GetError() );
     }
 
-    // Initialize game controllers
+    // Initialize game controller
     for (int i = 0; i < SDL_NumJoysticks(); ++i)
     {
         if (SDL_IsGameController(i)) {

--- a/src/go_window.cpp
+++ b/src/go_window.cpp
@@ -13,7 +13,7 @@ GoSDL::Window::Window (unsigned width, unsigned height, std::string caption, boo
     mLastTicks = SDL_GetTicks();
 
     // Init SDL
-    if (SDL_Init(SDL_INIT_VIDEO | SDL_INIT_AUDIO) < 0)
+    if (SDL_Init(SDL_INIT_VIDEO | SDL_INIT_AUDIO | SDL_INIT_JOYSTICK) < 0)
     {
         throw std::runtime_error(SDL_GetError());
     }
@@ -61,6 +61,12 @@ GoSDL::Window::Window (unsigned width, unsigned height, std::string caption, boo
     {
         throw std::runtime_error(IMG_GetError() );
     }
+
+    // Initialize joystick
+    if( SDL_NumJoysticks() > 0 )
+    {
+        joystick = SDL_JoystickOpen(0);
+    }
 }
 
 GoSDL::Window::~Window()
@@ -69,6 +75,10 @@ GoSDL::Window::~Window()
 	SDL_DestroyWindow( mWindow );
     mRenderer = NULL;
 	mWindow = NULL;
+
+    // Close joystick
+    SDL_JoystickClose(joystick);
+    joystick = NULL;
 
 	// Quit SDL subsystems
 	Mix_Quit();
@@ -127,8 +137,14 @@ void GoSDL::Window::show()
             case SDL_MOUSEBUTTONUP:
                 mouseButtonUp(e.button.button);
                 break;
-            }
 
+            case SDL_JOYBUTTONDOWN:
+            case SDL_JOYBUTTONUP:
+            case SDL_JOYAXISMOTION:
+            case SDL_JOYHATMOTION:
+                joystickEvent(e);
+                break;
+            }
         }
 
         // Process logic


### PR DESCRIPTION
This uses the game controller API in SDL2, meaning it should work with most controllers without the binds being strange. The binds are as follows:

- **A** - Select and swap gems and confirm in the menu.
- **Y** - Show hint.
- **Start** - Exit to menu.
- **Back** - Reset.
- **D-pad** - Move selector.