### PR TITLE
Reset the score when StateGame is reset

### DIFF
--- a/src/StateGame.cpp
+++ b/src/StateGame.cpp
@@ -141,6 +141,7 @@ void StateGame::loadResources()
 
 void StateGame::resetGame()
 {
+    mGameIndicators.setScore(0);
     resetTime();
     mGameBoard.resetGame();
 }


### PR DESCRIPTION
Currently when using the reset button the score isn't being reset. This means people can cheat quite badly really easily. It's a bit annoying if you're trying to see if you can beat your own score too. This PR addresses this issue.