### PR TITLE
Improve performance when rendering text shadows

### DIFF
--- a/include/BaseButton.h
+++ b/include/BaseButton.h
@@ -80,7 +80,7 @@ private:
     bool mHasIcon;
 
     /// Font used for the button's label
-    GoSDL::Image mImgCaption, mImgCaptionShadow;
+    GoSDL::Image mImgCaption;
 
     /// Position of the label within the button
     int mTextHorizontalPosition;

--- a/include/GameIndicators.h
+++ b/include/GameIndicators.h
@@ -79,12 +79,10 @@ private:
     /// Image for the clock
     GoSDL::Image mImgTime;
     GoSDL::Image mImgTimeHeader;
-    GoSDL::Image mImgTimeHeaderShadow;
 
     /// Image for the current-score
     GoSDL::Image mImgScore;
     GoSDL::Image mImgScoreHeader;
-    GoSDL::Image mImgScoreHeaderShadow;
 
     /// @{
     /// @name Buttons of the interface

--- a/include/StateHowToPlay.h
+++ b/include/StateHowToPlay.h
@@ -28,12 +28,9 @@ private:
     GoSDL::Image mImgBackground;
 
     GoSDL::Image mImgTitle;
-    GoSDL::Image mImgTitleShadow;
     GoSDL::Image mImgSubtitle;
-    GoSDL::Image mImgSubtitleShadow;
 
     GoSDL::Image mImgBodyText;
-    GoSDL::Image mImgBodyTextShadow;
 };
 
 #endif /* _STATEHOWTOPLAY_H_ */

--- a/include/StateMainMenu.h
+++ b/include/StateMainMenu.h
@@ -95,7 +95,6 @@ private:
     /// List of menu options.
     vector<string> mMenuTargets;
     vector<GoSDL::Image> mMenuRenderedTexts;
-    vector<GoSDL::Image> mMenuRenderedShadows;
 
     /// It gets executed when the user choses an option. It changes the state
     ///  to the proper one.

--- a/include/StateOptions.h
+++ b/include/StateOptions.h
@@ -75,7 +75,6 @@ private:
     /// List of menu options.
     vector<string> mMenuOptions;
     vector<GoSDL::Image> mMenuRenderedTexts;
-    vector<GoSDL::Image> mMenuRenderedShadows;
 
     /// It gets executed when the user choses an option. It changes the state
     ///  to the proper one.

--- a/include/go_font.h
+++ b/include/go_font.h
@@ -23,7 +23,12 @@ namespace GoSDL {
         int getTextWidth(std::string text);
 
         GoSDL::Image renderText(std::string text, SDL_Color color = {255, 255, 255, 255});
+        GoSDL::Image renderTextWithShadow(std::string text, SDL_Color color = {255, 255, 255, 255},
+                                          int shadowX = 0, int shadowY = 2, SDL_Color shadowColor = {0, 0, 0, 128});
+
         GoSDL::Image renderBlock(std::string text, SDL_Color color, unsigned width);
+        GoSDL::Image renderBlockWithShadow(std::string text, SDL_Color color, unsigned width,
+                                           int shadowX = 0, int shadowY = 2, SDL_Color shadowColor = {0, 0, 0, 128});
 
         ~Font();
 
@@ -34,6 +39,7 @@ namespace GoSDL {
 
         // Receives a surface and returns a pointer to an image (containing a texture)
         GoSDL::Image surfaceToImage (SDL_Surface * tempSurface);
+        GoSDL::Image surfaceToImageWithShadow (SDL_Surface * textSurface, SDL_Surface * shadowSurface, int shadowX, int shadowY);
 
         // Parent window
         Window * mParentWindow = NULL;

--- a/src/BaseButton.cpp
+++ b/src/BaseButton.cpp
@@ -31,8 +31,7 @@ void BaseButton::setText(std::string caption)
     textFont.setAll(mParentWindow, "media/fuenteNormal.ttf", 27);
 
     // Generate the button caption texture
-    mImgCaption = textFont.renderText(caption, {255, 255, 255, 255});
-    mImgCaptionShadow = textFont.renderText(caption, {0, 0, 0, 255});
+    mImgCaption = textFont.renderTextWithShadow(caption, {255, 255, 255, 255}, 1, 2, {0, 0, 0, 128});
 
     // Calculate the position of the text
     if (mHasIcon)
@@ -58,7 +57,6 @@ void BaseButton::draw(int x, int y, double z)
     }
 
     mImgCaption.draw(x + mTextHorizontalPosition, y + 5, z + 2);
-    mImgCaptionShadow.draw(x + mTextHorizontalPosition + 1, y + 7, z + 1,  1, 1, 1, 128);
 
     mImgBackground.draw(x, y, z);
 

--- a/src/GameIndicators.cpp
+++ b/src/GameIndicators.cpp
@@ -29,11 +29,9 @@ void GameIndicators::loadResources()
     GoSDL::Font tempHeaderFont;
     tempHeaderFont.setAll(mGame, "media/fuenteNormal.ttf", 37);
 
-    mImgScoreHeader = tempHeaderFont.renderText(_("score"), {160, 169, 255, 255});
-    mImgScoreHeaderShadow = tempHeaderFont.renderText(_("score"), {0,0,0, 255});
+    mImgScoreHeader = tempHeaderFont.renderTextWithShadow(_("score"), {160, 169, 255, 255}, 1, 1, {0, 0, 0, 128});
 
-    mImgTimeHeader = tempHeaderFont.renderText(_("time left"), {160, 169, 255, 255});
-    mImgTimeHeaderShadow = tempHeaderFont.renderText(_("time left"), {0,0,0, 255});
+    mImgTimeHeader = tempHeaderFont.renderTextWithShadow(_("time left"), {160, 169, 255, 255}, 1, 1, {0, 0, 0, 128});
 
     // Load the background image for the time
     mImgTimeBackground.setWindowAndPath(mGame, "media/timeBackground.png");
@@ -127,14 +125,12 @@ void GameIndicators::draw()
     // Draw the score
     mImgScoreBackground.draw(17, 124, 2);
     mImgScoreHeader.draw(17 + mImgScoreBackground.getWidth() / 2 - mImgScoreHeader.getWidth() / 2, 84, 3);
-    mImgScoreHeaderShadow.draw(18 + mImgScoreBackground.getWidth() / 2 - mImgScoreHeader.getWidth() / 2, 85, 2.95,  1, 1, 0, 128);
     mImgScore.draw(197 - mImgScore.getWidth(), 127, 2);
 
     // Draw the time
     if (mTimeEnabled) {
         mImgTimeBackground.draw(17, 230, 2);
         mImgTimeHeader . draw(17 + mImgTimeBackground.getWidth() / 2 - mImgTimeHeader.getWidth() / 2, 190, 3);
-        mImgTimeHeaderShadow . draw(18 + mImgTimeBackground.getWidth() / 2 - mImgTimeHeader.getWidth() / 2, 191, 2, 1, 1, 0, 128);
         mImgTime.draw(190 - mImgTime.getWidth(), 232, 2);
     }
 }

--- a/src/ScoreTable.cpp
+++ b/src/ScoreTable.cpp
@@ -38,9 +38,9 @@ ScoreTable::ScoreTable(Game * p, int score, string gameMode) : mGame(p)
     fntLcdSmall.setAll(mGame, "media/fuentelcd.ttf", 36);
 
     // Cache-render texts
-    mRenderedHeader = fntH1.renderText(_("GAME OVER"));
-    mRenderedScore = fntLcdBig.renderText(std::to_string(score));
-    mRenderedLastScore = fntH2.renderText(_("Latest high score: ") + std::to_string(lastScore));
+    mRenderedHeader = fntH1.renderTextWithShadow(_("GAME OVER"), {255, 255, 255, 255}, 1, 3, {0, 0, 0, 128});
+    mRenderedScore = fntLcdBig.renderTextWithShadow(std::to_string(score), {255, 255, 255, 255}, 1, 3, {0, 0, 0, 128});
+    mRenderedLastScore = fntH2.renderTextWithShadow(_("Latest high score: ") + std::to_string(lastScore), {255, 255, 255, 255}, 1, 3, {0, 0, 0, 128});
 }
 
 void ScoreTable::draw(int x, int y, int z)
@@ -50,16 +50,10 @@ void ScoreTable::draw(int x, int y, int z)
 
     // Draw the title and its shadow
     mRenderedHeader.draw(center - mRenderedHeader.getWidth() / 2, y, z);
-    mRenderedHeader.draw(center - mRenderedHeader.getWidth() / 2 + 1, y + 3, z - 1,
-        1, 1, 0, 128, {0, 0, 0, 255});
 
     // Draw the score and its shadow
     mRenderedScore.draw(center - mRenderedScore.getWidth() / 2, y + 67 + 10, z);
-    mRenderedScore.draw(center - mRenderedScore.getWidth() / 2 + 1, y + 70 + 10, z - 1,
-        1, 1, 0, 128, {0, 0, 0, 255});
 
     // Draw the score and its shadow
     mRenderedLastScore.draw(center - mRenderedLastScore.getWidth() / 2, y + 67 + 80, z);
-    mRenderedLastScore.draw(center - mRenderedLastScore.getWidth() / 2 + 1, y + 70 + 80, z - 1,
-        1, 1, 0, 128, {0, 0, 0, 255});
 }

--- a/src/StateHowtoplay.cpp
+++ b/src/StateHowtoplay.cpp
@@ -17,8 +17,7 @@ StateHowtoplay::StateHowtoplay(Game * p) : State(p)
     fontTitle.setWindow(p);
     fontTitle.setPathAndSize("media/fuenteMenu.ttf", 48);
 
-    mImgTitle = fontTitle.renderText(_("How to play"), {255, 255, 255, 255});
-    mImgTitleShadow = fontTitle.renderText(_("How to play"), {0, 0, 0, 255});
+    mImgTitle = fontTitle.renderTextWithShadow(_("How to play"), {255, 255, 255, 255}, 1, 2, {0, 0, 0, 128});
 
     // Build the subtitle text
     GoSDL::Font fontSubtitle;
@@ -28,8 +27,7 @@ StateHowtoplay::StateHowtoplay(Game * p) : State(p)
 
     std::string subtitleText = _("Press any button to go back");
 
-    mImgSubtitle = fontSubtitle.renderText(subtitleText.c_str(), {255, 255, 255, 255});
-    mImgSubtitleShadow = fontSubtitle.renderText(subtitleText.c_str(), {0, 0, 0, 255});
+    mImgSubtitle = fontSubtitle.renderTextWithShadow(subtitleText.c_str(), {255, 255, 255, 255}, 1, 2, {0, 0, 0, 128});
 
     // Build the main text
     GoSDL::Font fontText;
@@ -45,8 +43,7 @@ StateHowtoplay::StateHowtoplay(Game * p) : State(p)
     bodyText += "\n\n";
     bodyText += _("Bonus points are given when more than three identical gems are formed. Sometimes chain reactions, called cascades, are triggered, where chains are formed by the falling gems. Cascades are awarded with bonus points.");
 
-    mImgBodyText = fontText.renderBlock(bodyText.c_str(), {255, 255, 255, 255}, 450);
-    mImgBodyTextShadow = fontText.renderBlock(bodyText.c_str(), {0, 0, 0, 255}, 450);
+    mImgBodyText = fontText.renderBlockWithShadow(bodyText.c_str(), {255, 255, 255, 255}, 450, 1, 2, {0, 0, 0, 128});
 }
 
 void StateHowtoplay::update() { }
@@ -56,13 +53,10 @@ void StateHowtoplay::draw()
     mImgBackground.draw(0,0,0);
 
     mImgTitle.draw(300 + 470 / 2 - mImgTitle.getWidth() / 2, 20, 1);
-    mImgTitleShadow.draw(301 + 470 / 2 - mImgTitle.getWidth() / 2, 22, 0.9, 1, 1, 0, 128);
 
     mImgSubtitle.draw(30, 550, 1);
-    mImgSubtitleShadow.draw(30 + 1, 550 + 2, 0.9, 1, 1, 0, 128);
 
     mImgBodyText.draw(310, 110, 1);
-    mImgBodyTextShadow.draw(311, 112, 0.9,  1, 1, 0, 128);
 }
 
 void StateHowtoplay::buttonDown(SDL_Keycode)

--- a/src/StateMainMenu.cpp
+++ b/src/StateMainMenu.cpp
@@ -45,20 +45,12 @@ StateMainMenu::StateMainMenu(Game * p) : State(p)
     mMenuTargets = {"stateGameTimetrial", "stateGameEndless", "stateHowtoplay", "stateOptions", "stateQuit"};
 
     // Menu text items
-    SDL_Color menuTextColor = {255, 255, 255, 255};
-    mMenuRenderedTexts.push_back(mFont.renderText(_("Timetrial mode"), menuTextColor));
-    mMenuRenderedTexts.push_back(mFont.renderText(_("Endless mode"), menuTextColor));
-    mMenuRenderedTexts.push_back(mFont.renderText(_("How to play?"), menuTextColor));
-    mMenuRenderedTexts.push_back(mFont.renderText(_("Options"), menuTextColor));
-    mMenuRenderedTexts.push_back(mFont.renderText(_("Exit"), menuTextColor));
-
-    // Menu shadows
-    menuTextColor = {0,0,0, 255};
-    mMenuRenderedShadows.push_back(mFont.renderText(_("Timetrial mode"), menuTextColor));
-    mMenuRenderedShadows.push_back(mFont.renderText(_("Endless mode"), menuTextColor));
-    mMenuRenderedShadows.push_back(mFont.renderText(_("How to play?"), menuTextColor));
-    mMenuRenderedShadows.push_back(mFont.renderText(_("Options"), menuTextColor));
-    mMenuRenderedShadows.push_back(mFont.renderText(_("Exit"), menuTextColor));
+    SDL_Color menuTextColor = {255, 255, 255, 255}, menuShadowColor = {0, 0, 0, 128};
+    mMenuRenderedTexts.push_back(mFont.renderTextWithShadow(_("Timetrial mode"), menuTextColor, 0, 2, menuShadowColor));
+    mMenuRenderedTexts.push_back(mFont.renderTextWithShadow(_("Endless mode"), menuTextColor, 0, 2, menuShadowColor));
+    mMenuRenderedTexts.push_back(mFont.renderTextWithShadow(_("How to play?"), menuTextColor, 0, 2, menuShadowColor));
+    mMenuRenderedTexts.push_back(mFont.renderTextWithShadow(_("Options"), menuTextColor, 0, 2, menuShadowColor));
+    mMenuRenderedTexts.push_back(mFont.renderTextWithShadow(_("Exit"), menuTextColor, 0, 2, menuShadowColor));
 
     // Jewel group animation
     mJewelAnimation.loadResources(p);
@@ -124,8 +116,6 @@ void StateMainMenu::draw(){
 
         // Draw the text and the shadow
         mMenuRenderedTexts[i].draw(posX, posY, 3);
-        mMenuRenderedShadows[i].draw(posX, posY + 2, 2.9, 1, 1, 0, 128);
-
     }
 
     // Draw the menu highlighting

--- a/src/StateOptions.cpp
+++ b/src/StateOptions.cpp
@@ -81,7 +81,6 @@ void StateOptions::draw(){
 
         // Draw the text and the shadow
         mMenuRenderedTexts[i].draw(posX, posY, 3);
-        mMenuRenderedShadows[i].draw(posX, posY + 2, 2.9, 1, 1, 0, 128);
     }
 
     // Draw the menu highlighting
@@ -167,7 +166,6 @@ void StateOptions::moveDown() {
 void StateOptions::updateButtonTexts()
 {
     vector<GoSDL::Image> renderedTexts;
-    vector<GoSDL::Image> renderedShadows;
 
     // Option strings
     std::string musicText = _("Music: ");
@@ -179,25 +177,15 @@ void StateOptions::updateButtonTexts()
     fullscreenText += std::string(mOptions.getFullscreenEnabled() ? _("On") : _("Off"));
 
     // Menu text items
-    SDL_Color menuTextColor = {255, 255, 255, 255};
-    renderedTexts.push_back(mFont.renderText(musicText, menuTextColor));
-    renderedTexts.push_back(mFont.renderText(soundText, menuTextColor));
+    SDL_Color menuTextColor = {255, 255, 255, 255}, menuShadowColor = {0,0,0, 128};
+    renderedTexts.push_back(mFont.renderTextWithShadow(musicText, menuTextColor, 0, 2, menuShadowColor));
+    renderedTexts.push_back(mFont.renderTextWithShadow(soundText, menuTextColor, 0, 2, menuShadowColor));
     #ifndef __vita__
-        renderedTexts.push_back(mFont.renderText(fullscreenText, menuTextColor));
+        renderedTexts.push_back(mFont.renderTextWithShadow(fullscreenText, menuTextColor, 0, 2, menuShadowColor));
     #endif
-    renderedTexts.push_back(mFont.renderText(_("Back"), menuTextColor));
-
-    // Menu shadows
-    menuTextColor = {0,0,0, 255};
-    renderedShadows.push_back(mFont.renderText(musicText, menuTextColor));
-    renderedShadows.push_back(mFont.renderText(soundText, menuTextColor));
-    #ifndef __vita__
-        renderedShadows.push_back(mFont.renderText(fullscreenText, menuTextColor));
-    #endif
-    renderedShadows.push_back(mFont.renderText(_("Back"), menuTextColor));
+    renderedTexts.push_back(mFont.renderTextWithShadow(_("Back"), menuTextColor, 0, 2, menuShadowColor));
 
     mMenuRenderedTexts.swap(renderedTexts);
-    mMenuRenderedShadows.swap(renderedShadows);
 }
 
 void StateOptions::optionChosen()

--- a/src/go_font.cpp
+++ b/src/go_font.cpp
@@ -72,10 +72,24 @@ GoSDL::Image GoSDL::Font::renderText (std::string text, SDL_Color color) {
     return surfaceToImage(tempSurface);
 }
 
+GoSDL::Image GoSDL::Font::renderTextWithShadow (std::string text, SDL_Color color, int shadowX, int shadowY, SDL_Color shadowColor) {
+
+    SDL_Surface * textSurface = TTF_RenderUTF8_Blended(mFont, text.c_str(), color);
+    SDL_Surface * shadowSurface = TTF_RenderUTF8_Blended(mFont, text.c_str(), shadowColor);
+    return surfaceToImageWithShadow(textSurface, shadowSurface, shadowX, shadowY);
+}
+
 GoSDL::Image GoSDL::Font::renderBlock (std::string text, SDL_Color color, unsigned width) {
 
     SDL_Surface * tempSurface = TTF_RenderUTF8_Blended_Wrapped(mFont, text.c_str(), color, width);
     return surfaceToImage(tempSurface);
+}
+
+GoSDL::Image GoSDL::Font::renderBlockWithShadow (std::string text, SDL_Color color, unsigned width, int shadowX, int shadowY, SDL_Color shadowColor) {
+
+    SDL_Surface * textSurface = TTF_RenderUTF8_Blended_Wrapped(mFont, text.c_str(), color, width);
+    SDL_Surface * shadowSurface = TTF_RenderUTF8_Blended_Wrapped(mFont, text.c_str(), shadowColor, width);
+    return surfaceToImageWithShadow(textSurface, shadowSurface, shadowX, shadowY);
 }
 
 GoSDL::Image GoSDL::Font::surfaceToImage (SDL_Surface * tempSurface) {
@@ -88,4 +102,28 @@ GoSDL::Image GoSDL::Font::surfaceToImage (SDL_Surface * tempSurface) {
     img.setTexture(tempTexture);
 
     return img;
+}
+
+GoSDL::Image GoSDL::Font::surfaceToImageWithShadow (SDL_Surface * textSurface, SDL_Surface * shadowSurface, int shadowX, int shadowY) {
+    SDL_Rect rect;
+
+    SDL_Surface * tempSurface = SDL_CreateRGBSurfaceWithFormat(0, shadowX + shadowSurface->w, shadowY + shadowSurface->h, 32, SDL_PIXELFORMAT_RGBA32);
+
+    rect.x = shadowX;
+    rect.y = shadowY;
+    rect.w = shadowSurface->w;
+    rect.w = shadowSurface->h;
+    SDL_SetSurfaceBlendMode(shadowSurface, SDL_BLENDMODE_NONE);
+    SDL_BlitSurface(shadowSurface, NULL, tempSurface, &rect);
+    SDL_FreeSurface(shadowSurface);
+
+    rect.x = 0;
+    rect.y = 0;
+    rect.w = textSurface->w;
+    rect.w = textSurface->h;
+    SDL_SetSurfaceBlendMode(textSurface, SDL_BLENDMODE_BLEND);
+    SDL_BlitSurface(textSurface, NULL, tempSurface, &rect);
+    SDL_FreeSurface(textSurface);
+
+    return surfaceToImage(tempSurface);
 }


### PR DESCRIPTION
When using SDL's software renderer, alpha modulation is quite slow. Setting the alpha value in `TTF_RenderUTF8_Blended` provides a useful performance improvement, and this PR also provides a smaller performance and memory improvement by combining the text and shadow before uploading it to a texture.