### PR TITLE
Clean up code for showing the cursor

### DIFF
--- a/include/Game.h
+++ b/include/Game.h
@@ -36,8 +36,6 @@ public:
         return &mGameSounds;
     }
 
-    bool isCursorVisible() {return mMouseActive;}
-
 private:
 
     std::shared_ptr<State> mCurrentState = nullptr;
@@ -47,14 +45,6 @@ private:
 
     /// Sounds controller
     GameSounds mGameSounds;
-
-    bool mMouseActive = true;
-    int mLastMouseX;
-    int mLastMouseY;
-
-    void hideCursor();
-    void showCursor();
-
 };
 
 #endif /* _GAME_H_ */

--- a/include/go_window.h
+++ b/include/go_window.h
@@ -93,6 +93,11 @@ namespace GoSDL {
         virtual void controllerButtonDown(Uint8) { }
 
         /**
+         * @brief Returns if the mouse is in use
+         */
+        int getMouseActive() { return mMouseActive; }
+
+        /**
          * @brief Returns the horizontal position of the mouse
          */
         int getMouseX() { return mMouseX; }
@@ -152,6 +157,9 @@ namespace GoSDL {
 
         /// Ticks recorded in last frame
         Uint32 mLastTicks;
+
+        // Whether the mouse is in use
+        bool mMouseActive = false;
 
         /// Mouse coordinates
         int mMouseX, mMouseY;

--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -16,8 +16,6 @@ Game::Game ()
     mMouseCursor.setWindow(this);
     mMouseCursor.setPath("media/handCursor.png");
 
-    hideCursor();
-
     changeState("stateMainMenu");
 }
 
@@ -28,9 +26,6 @@ Game::~Game()
 
 void Game::update ()
 {
-    if (!mMouseActive && (mLastMouseX != getMouseX() || mLastMouseY != getMouseY())) {
-        showCursor();
-    }
     if (mCurrentState)
         mCurrentState -> update();
 }
@@ -38,7 +33,7 @@ void Game::update ()
 void Game::draw ()
 {
     #ifndef __vita__
-        if (mMouseActive) {
+        if (getMouseActive()) {
             mMouseCursor.draw(getMouseX(), getMouseY(), 999);
         }
     #endif
@@ -49,7 +44,6 @@ void Game::draw ()
 
 void Game::buttonDown (SDL_Keycode button)
 {
-    hideCursor();
     if (mCurrentState)
         mCurrentState -> buttonDown(button);
 }
@@ -62,7 +56,6 @@ void Game::buttonUp (SDL_Keycode button)
 
 void Game::mouseButtonDown (Uint8 button)
 {
-    showCursor();
     if (mCurrentState)
         mCurrentState -> mouseButtonDown(button);
 }
@@ -75,21 +68,8 @@ void Game::mouseButtonUp (Uint8 button)
 
 void Game::controllerButtonDown (Uint8 button)
 {
-    hideCursor();
     if (mCurrentState)
         mCurrentState -> controllerButtonDown(button);
-}
-
-void Game::hideCursor() {
-    if (mMouseActive) {
-        mLastMouseX = getMouseX();
-        mLastMouseY = getMouseY();
-        mMouseActive = false;
-    }
-}
-
-void Game::showCursor() {
-    mMouseActive = true;
 }
 
 void Game::changeState(string S)

--- a/src/GameBoard.cpp
+++ b/src/GameBoard.cpp
@@ -279,7 +279,7 @@ void GameBoard::update()
 
 void GameBoard::draw()
 {
-    if (mGame->isCursorVisible()) {
+    if (mGame->getMouseActive()) {
         // Get mouse position
         int mX = (int) mGame -> getMouseX();
         int mY = (int) mGame -> getMouseY();

--- a/src/StateMainMenu.cpp
+++ b/src/StateMainMenu.cpp
@@ -84,7 +84,7 @@ void StateMainMenu::update(){
 
     }
 
-    if (mGame->isCursorVisible()) {
+    if (mGame->getMouseActive()) {
         // Update menu highlighting according to mouse position
         int mY = (int) mGame -> getMouseY();
 

--- a/src/StateOptions.cpp
+++ b/src/StateOptions.cpp
@@ -56,7 +56,7 @@ StateOptions::StateOptions(Game * p) : State(p)
 
 void StateOptions::update(){
 
-    if (mGame->isCursorVisible()) {
+    if (mGame->getMouseActive()) {
         // Update menu highlighting according to mouse position
         int mY = (int) mGame -> getMouseY();
 

--- a/src/go_window.cpp
+++ b/src/go_window.cpp
@@ -146,6 +146,7 @@ void GoSDL::Window::show()
                 break;
 
             case SDL_KEYDOWN:
+                mMouseActive = false;
                 buttonDown(e.key.keysym.sym);
                 break;
 
@@ -154,11 +155,13 @@ void GoSDL::Window::show()
                 break;
 
             case SDL_MOUSEMOTION:
+                mMouseActive = true;
                 mMouseX = (e.motion.x * mWidth) / mWindowWidth;
                 mMouseY = (e.motion.y * mHeight) / mWindowHeight;
                 break;
 
             case SDL_MOUSEBUTTONDOWN:
+                mMouseActive = true;
                 mouseButtonDown(e.button.button);
                 break;
 
@@ -167,6 +170,7 @@ void GoSDL::Window::show()
                 break;
 
             case SDL_CONTROLLERBUTTONDOWN:
+                mMouseActive = false;
                 controllerButtonDown(e.cbutton.button);
                 break;
 


### PR DESCRIPTION
This also makes it more reliable. Before this change, sometimes the
cursor just wouldn't appear. This change makes sure the mouse always
shows up when it is moved or when a click is made and is always hidden
when the keyboard or a controller is used.