### PR TITLE
docs: Homebrew added to LIBRARY_PATH for OSX instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,13 @@ This assumes that you are already using [Homebrew](https://brew.sh/). You will n
 
     brew install cmake sdl2 sdl2_mixer sdl2_ttf sdl2_image gettext jsoncpp
 
+Now run the following commands to setup your environment to use Homebrew as a backup location for libraries.
+
+```
+[[ -z "${LIBRARY_PATH}" ]] && export LIBRARY_PATH=/usr/local/lib
+export LIBRARY_PATH="$LIBRARY_PATH:$(brew --prefix)/lib"
+```
+
 Now follow the instructions above, starting with `git clone`.
 
 ## Installation on Playstation Vita


### PR DESCRIPTION
So basically, this is AMAZING; Someone posted to a Haiku (Operating System) forum they'd ported this and I was on my Mac and had never heard of it.

Unfortunately following the instructions did not work for me and required the small additional steps documented so that the `make` command would succeed.

Error, prior to this change.

```
> $ make
[  0%] Built target link_media_folder
[  3%] Linking CXX executable freegemas
ld: library not found for -lSDL2_image
clang: error: linker command failed with exit code 1 (use -v to see invocation)
make[2]: *** [freegemas] Error 1
make[1]: *** [CMakeFiles/freegemas.dir/all] Error 2
make: *** [all] Error 2
```

* This change respects the users current `LIBRARY_PATH` setting
* This change uses a homebrew command, which I hope will make it relatively future-proof