### PR TITLE
Fix automated builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,8 +80,8 @@ jobs:
     steps:
       - name: install dependencies
         run: |
-          brew install cmake sdl2 sdl2_mixer sdl2_ttf sdl2_image gettext jsoncpp
-          brew link gettext --force --overwrite
+          brew install cmake sdl2 sdl2_mixer sdl2_ttf sdl2_image jsoncpp
+          brew reinstall gettext brew unlink gettext && brew link gettext --force --overwrite
       - name: checkout
         uses: actions/checkout@v4
       - name: build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,13 +80,13 @@ jobs:
     steps:
       - name: install dependencies
         run: |
-          brew install sdl2 sdl2_mixer sdl2_ttf sdl2_image jsoncpp gettext
+          brew install sdl2 sdl2_mixer sdl2_ttf sdl2_image jsoncpp
       - name: checkout
         uses: actions/checkout@v4
       - name: build
         run: |
           [[ -z "${LIBRARY_PATH}" ]] && export LIBRARY_PATH=/usr/local/lib
-          export LIBRARY_PATH="$LIBRARY_PATH:$(brew --prefix)/lib:$(brew --prefix)/gettext/lib"
+          export LIBRARY_PATH="$LIBRARY_PATH:$(brew --prefix)/lib"
           cmake -DCMAKE_BUILD_TYPE=Release .
           make
           strip freegemas

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,7 +80,7 @@ jobs:
     steps:
       - name: install dependencies
         run: |
-          brew install sdl2 sdl2_mixer sdl2_ttf sdl2_image jsoncpp gettext
+          brew install sdl2 sdl2_mixer sdl2_ttf sdl2_image jsoncpp
       - name: checkout
         uses: actions/checkout@v4
       - name: build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,13 +80,13 @@ jobs:
     steps:
       - name: install dependencies
         run: |
-          brew install sdl2 sdl2_mixer sdl2_ttf sdl2_image jsoncpp
+          brew install sdl2 sdl2_mixer sdl2_ttf sdl2_image jsoncpp gettext
       - name: checkout
         uses: actions/checkout@v4
       - name: build
         run: |
           [[ -z "${LIBRARY_PATH}" ]] && export LIBRARY_PATH=/usr/local/lib
-          export LIBRARY_PATH="$LIBRARY_PATH:$(brew --prefix)/lib"
+          export LIBRARY_PATH="$LIBRARY_PATH:$(brew --prefix)/lib:$(brew --prefix)/gettext/lib"
           cmake -DCMAKE_BUILD_TYPE=Release .
           make
           strip freegemas

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,10 +80,7 @@ jobs:
     steps:
       - name: install dependencies
         run: |
-          brew install sdl2 sdl2_mixer sdl2_ttf sdl2_image jsoncpp
-          brew reinstall gettext
-          brew unlink gettext
-          brew link gettext --force --overwrite
+          brew install sdl2 sdl2_mixer sdl2_ttf sdl2_image jsoncpp gettext
       - name: checkout
         uses: actions/checkout@v4
       - name: build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -85,6 +85,8 @@ jobs:
         uses: actions/checkout@v4
       - name: build
         run: |
+          [[ -z "${LIBRARY_PATH}" ]] && export LIBRARY_PATH=/usr/local/lib
+          export LIBRARY_PATH="$LIBRARY_PATH:$(brew --prefix)/lib"
           cmake -DCMAKE_BUILD_TYPE=Release .
           make
           strip freegemas

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -81,7 +81,9 @@ jobs:
       - name: install dependencies
         run: |
           brew install cmake sdl2 sdl2_mixer sdl2_ttf sdl2_image jsoncpp
-          brew reinstall gettext brew unlink gettext && brew link gettext --force --overwrite
+          brew reinstall gettext
+          brew unlink gettext
+          brew link gettext --force --overwrite
       - name: checkout
         uses: actions/checkout@v4
       - name: build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,7 +80,7 @@ jobs:
     steps:
       - name: install dependencies
         run: |
-          brew install cmake sdl2 sdl2_mixer sdl2_ttf sdl2_image jsoncpp
+          brew install sdl2 sdl2_mixer sdl2_ttf sdl2_image jsoncpp
           brew reinstall gettext
           brew unlink gettext
           brew link gettext --force --overwrite

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -81,6 +81,7 @@ jobs:
       - name: install dependencies
         run: |
           brew install cmake sdl2 sdl2_mixer sdl2_ttf sdl2_image gettext jsoncpp
+          brew link gettext --force --overwrite
       - name: checkout
         uses: actions/checkout@v4
       - name: build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,6 +36,10 @@ jobs:
   Windows:
     runs-on: windows-latest
 
+    defaults:
+      run:
+        shell: msys2 {0}
+
     steps:
       - name: Install dependencies
         uses: msys2/setup-msys2@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -86,7 +86,7 @@ jobs:
       - name: build
         run: |
           [[ -z "${LIBRARY_PATH}" ]] && export LIBRARY_PATH=/usr/local/lib
-          export LIBRARY_PATH="$LIBRARY_PATH:$(brew --prefix)/lib:/opt/homebrew/opt/gettext/lib"
+          export LIBRARY_PATH="$LIBRARY_PATH:$(brew --prefix)/lib:$(brew --prefix)/gettext/lib"
           cmake -DCMAKE_BUILD_TYPE=Release .
           make
           strip freegemas

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y wget cmake g++ libsdl2-dev libsdl2-image-dev libsdl2-ttf-dev libsdl2-mixer-dev libjsoncpp-dev libfuse2
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: build
         run: |
           cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr .
@@ -25,7 +25,7 @@ jobs:
           chmod +x linuxdeploy*.AppImage
           ./linuxdeploy-x86_64.AppImage --appdir AppDir --output appimage
       - name: publish artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: freegemas-linux
           path: |
@@ -58,14 +58,14 @@ jobs:
             mingw-w64-x86_64-jsoncpp
           update: true
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Build
         run: |
           cmake -DCMAKE_BUILD_TYPE=Release -G "MinGW Makefiles" .
           cmake --build .
           strip --strip-unneeded freegemas.exe
       - name: Publish artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: freegemas-windows
           path: |
@@ -82,14 +82,14 @@ jobs:
         run: |
           brew install cmake sdl2 sdl2_mixer sdl2_ttf sdl2_image gettext jsoncpp
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: build
         run: |
           cmake -DCMAKE_BUILD_TYPE=Release .
           make
           strip freegemas
       - name: publish artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: freegemas-macos
           path: |
@@ -104,13 +104,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Build
         run: |
           cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE="${VITASDK}/share/vita.toolchain.cmake" .
           make
       - name: Publish artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: freegemas-vita
           path: |
@@ -129,7 +129,7 @@ jobs:
     - name: Extract tag name
       id: tag
       run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
-    - uses: actions/download-artifact@v2
+    - uses: actions/download-artifact@v4
     - name: Zip artifacts
       run: |
         zip -r freegemas-${{matrix.build}}.zip freegemas-${{matrix.build}}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,24 +38,37 @@ jobs:
 
     steps:
       - name: Install dependencies
-        run: |
-          vcpkg install --triplet x64-windows-static sdl2 sdl2-image sdl2-ttf sdl2-mixer[libvorbis] jsoncpp
+        uses: msys2/setup-msys2@v2
+        with:
+          msystem: MINGW64
+          install: >-
+            mingw-w64-x86_64-gcc
+            mingw-w64-x86_64-binutils
+            mingw-w64-x86_64-make
+            mingw-w64-x86_64-cmake
+            mingw-w64-x86_64-pkgconf
+            mingw-w64-x86_64-SDL2
+            mingw-w64-x86_64-SDL2_image
+            mingw-w64-x86_64-SDL2_mixer
+            mingw-w64-x86_64-SDL2_ttf
+            mingw-w64-x86_64-jsoncpp
+          update: true
       - name: Checkout
         uses: actions/checkout@v2
       - name: Build
         run: |
-          cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE=C:\vcpkg\scripts\buildsystems\vcpkg.cmake -DVCPKG_TARGET_TRIPLET=x64-windows-static -DBUILD_STATIC=ON .
-          cmake --build . --config Release
-          cp Release/freegemas.exe .
-          cp LICENSE Release/LICENSE.txt
-          cp README.md Release/README.txt
-          cp -Recurse media Release
+          cmake -DCMAKE_BUILD_TYPE=Release -G "MinGW Makefiles" .
+          cmake --build .
+          strip --strip-unneeded freegemas.exe
       - name: Publish artifacts
         uses: actions/upload-artifact@v2
         with:
           name: freegemas-windows
           path: |
-            Release
+            freegemas.exe
+            media
+            LICENSE
+            README.md
 
   MacOS:
     runs-on: macos-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -86,7 +86,7 @@ jobs:
       - name: build
         run: |
           [[ -z "${LIBRARY_PATH}" ]] && export LIBRARY_PATH=/usr/local/lib
-          export LIBRARY_PATH="$LIBRARY_PATH:$(brew --prefix)/lib"
+          export LIBRARY_PATH="$LIBRARY_PATH:$(brew --prefix)/lib:/opt/homebrew/opt/gettext/lib"
           cmake -DCMAKE_BUILD_TYPE=Release .
           make
           strip freegemas

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -85,8 +85,8 @@ jobs:
         uses: actions/checkout@v4
       - name: build
         run: |
-          [[ -z "${LIBRARY_PATH}" ]] && export LIBRARY_PATH=/usr/local/lib
-          export LIBRARY_PATH="$LIBRARY_PATH:$(brew --prefix)/lib:$(brew --prefix)/gettext/lib"
+          export CPATH=$(brew --prefix)/include
+          export LIBRARY_PATH=$(brew --prefix)/lib
           cmake -DCMAKE_BUILD_TYPE=Release .
           make
           strip freegemas

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -96,7 +96,7 @@ jobs:
 
   Vita:
     runs-on: ubuntu-latest
-    container: gnuton/vitasdk-docker:latest
+    container: vitasdk/vitasdk:latest
 
     steps:
       - name: Checkout

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,7 @@ else()
 endif()
 
 set(BUILD_STATIC_DEFAULT OFF)
-if(WIN32 OR VITA OR PSP)
+if(WIN32 OR VITA)
     set(BUILD_STATIC_DEFAULT ON)
 endif()
 option(BUILD_STATIC "Build a static binary" ${BUILD_STATIC_DEFAULT})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,18 +85,6 @@ include_directories(
     ${JSONCPP_INCLUDE_DIRS}
 )
 
-if(NOT VITA)
-	add_custom_target(
-		link_media_folder
-		COMMAND ln -nfs ${PROJECT_SOURCE_DIR}/media ${PROJECT_BINARY_DIR}/media
-	)
-
-	add_dependencies(
-		freegemas
-		link_media_folder
-	)
-endif()
-
 if (VITA)
 	include("$ENV{VITASDK}/share/vita.cmake" REQUIRED)
 
@@ -119,6 +107,16 @@ if (VITA)
 ELSEIF(WIN32)
 	# Nothing to do
 ELSE()
+	add_custom_target(
+		link_media_folder
+		COMMAND ln -nfs ${PROJECT_SOURCE_DIR}/media ${PROJECT_BINARY_DIR}/media
+	)
+
+	add_dependencies(
+		freegemas
+		link_media_folder
+	)
+
 	install(TARGETS freegemas DESTINATION bin)
 	install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/media DESTINATION share/freegemas)
 	install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/platform/unix/freegemas.desktop DESTINATION share/applications)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,6 +66,7 @@ if(BUILD_STATIC)
         ${SDL2_TTF_STATIC_LIBRARIES}
         ${JSONCPP_STATIC_LIBRARIES}
     )
+	if
 else()
     target_link_libraries(freegemas PRIVATE
         ${SDL2_LIBRARIES}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,28 +1,6 @@
 project(freegemas_project)
 cmake_minimum_required(VERSION 3.0)
 
-# Append custom gettext path to CMAKE_PREFIX_PATH - only necessary on OS X.
-if (CMAKE_HOST_APPLE)
-    find_program(HOMEBREW_PROG brew)
-    if (EXISTS ${HOMEBREW_PROG})
-        execute_process(COMMAND ${HOMEBREW_PROG} --prefix gettext
-            OUTPUT_STRIP_TRAILING_WHITESPACE
-            OUTPUT_VARIABLE HOMEBREW_GETTEXT_PREFIX)
-        list(APPEND CMAKE_PREFIX_PATH "${HOMEBREW_GETTEXT_PREFIX}")
-    endif()
-
-    find_path(LIBINTL_INCLUDE_DIRS
-        NAMES libintl.h
-        PATH_SUFFIXES gettext
-    )
-
-    find_library(LIBINTL_LIBRARIES
-        NAMES intl libintl.a
-    )
-endif()
-
-
-
 if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -pedantic -std=c++11 -O")
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
+cmake_minimum_required(VERSION 3.5)
 project(freegemas_project)
-cmake_minimum_required(VERSION 3.0)
 
 if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -pedantic -std=c++11 -O")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,8 +31,6 @@ file(GLOB SOURCE_FILES
     ${PROJECT_SOURCE_DIR}/src/*.cpp
 )
 
-# MESSAGE(STATUS "SOURCE FILES: " ${SOURCE_FILES})
-
 if(WIN32)
 	add_executable (freegemas WIN32
 		${SOURCE_FILES}
@@ -44,16 +42,62 @@ else()
 	)
 endif()
 
-if (VITA)
-	# VITASDK defines
-	if(NOT DEFINED CMAKE_TOOLCHAIN_FILE)
-		if(DEFINED ENV{VITASDK})
-			set(CMAKE_TOOLCHAIN_FILE "$ENV{VITASDK}/share/vita.toolchain.cmake" CACHE PATH "toolchain file")
-		    else()
-			message(FATAL_ERROR "Please define VITASDK to point to your SDK path!")
-		    endif()
-	endif()
+set(BUILD_STATIC_DEFAULT OFF)
+if(WIN32 OR VITA OR PSP)
+    set(BUILD_STATIC_DEFAULT ON)
+endif()
+option(BUILD_STATIC "Build a static binary" ${BUILD_STATIC_DEFAULT})
 
+# Find libraries
+include(FindPkgConfig)
+pkg_search_module(SDL2 REQUIRED sdl2)
+pkg_search_module(SDL2_IMAGE REQUIRED SDL2_image)
+pkg_search_module(SDL2_MIXER REQUIRED SDL2_mixer)
+pkg_search_module(SDL2_TTF REQUIRED SDL2_ttf)
+pkg_search_module(JSONCPP REQUIRED jsoncpp)
+
+# Link libraries
+if(BUILD_STATIC)
+    set(CMAKE_CXX_FLAGS "-static ${CMAKE_CXX_FLAGS}")
+    target_link_libraries(freegemas PRIVATE
+        ${SDL2_STATIC_LIBRARIES}
+        ${SDL2_IMAGE_STATIC_LIBRARIES}
+        ${SDL2_MIXER_STATIC_LIBRARIES}
+        ${SDL2_TTF_STATIC_LIBRARIES}
+        ${JSONCPP_STATIC_LIBRARIES}
+    )
+else()
+    target_link_libraries(freegemas PRIVATE
+        ${SDL2_LIBRARIES}
+        ${SDL2_IMAGE_LIBRARIES}
+        ${SDL2_MIXER_LIBRARIES}
+        ${SDL2_TTF_LIBRARIES}
+        ${JSONCPP_LIBRARIES}
+    )
+endif()
+
+include_directories(
+    ${PROJECT_SOURCE_DIR}/include
+    ${SDL2_INCLUDE_DIRS}
+    ${SDL2_IMAGE_INCLUDE_DIRS}
+    ${SDL2_MIXER_INCLUDE_DIRS}
+    ${SDL2_TTF_INCLUDE_DIRS}
+    ${JSONCPP_INCLUDE_DIRS}
+)
+
+if(NOT VITA)
+	add_custom_target(
+		link_media_folder
+		COMMAND ln -nfs ${PROJECT_SOURCE_DIR}/media ${PROJECT_BINARY_DIR}/media
+	)
+
+	add_dependencies(
+		freegemas
+		link_media_folder
+	)
+endif()
+
+if (VITA)
 	include("$ENV{VITASDK}/share/vita.cmake" REQUIRED)
 
 	# Project start
@@ -64,55 +108,6 @@ if (VITA)
 	# Optional. You can specify more param.sfo flags this way.
 	set(VITA_MKSFOEX_FLAGS "${VITA_MKSFOEX_FLAGS} -d PARENTAL_LEVEL=1")
 
-	set(VITA_INCLUDE_DIR "$ENV{VITASDK}/arm-vita-eabi/include/")
-	set(SDL2_INCLUDE_DIR "$ENV{VITASDK}/arm-vita-eabi/include/SDL2")
-	set(WEBP_INCLUDE_DIR "$ENV{VITASDK}/arm-vita-eabi/include/webp")
-	set(PNG_INCLUDE_DIR "$ENV{VITASDK}/arm-vita-eabi/include/libpng16")
-	set(FLAC_INCLUDE_DIR "$ENV{VITASDK}/arm-vita-eabi/include/FLAC")
-	set(JSON_INCLUDE_DIR "$ENV{VITASDK}/arm-vita-eabi/include/jsoncpp")
-
-	include_directories(${PROJECT_SOURCE_DIR}/include
-			${VITA_INCLUDE_DIR}
-			${SDL2_INCLUDE_DIR}
-			${WEBP_INCLUDE_DIR}
-			${PNG_INCLUDE_DIR}
-			${FLAC_INCLUDE_DIR}
-			${JSON_INCLUDE_DIR}
-	)
-
-	target_link_libraries(freegemas
-		SDL2_image
-		SDL2_ttf
-		SDL2_mixer
-		SDL2
-		jsoncpp
-		stdc++
-		webp
-		pthread
-		png16
-		freetype
-		vorbisfile
-		vorbis
-		ogg
-		modplug
-		jpeg
-		z
-		m
-		mikmod
-		mpg123
-		FLAC
-		SceAppUtil_stub
-		SceAudio_stub
-		SceAudioIn_stub
-		SceCommonDialog_stub
-		SceCtrl_stub
-		SceDisplay_stub
-		SceGxm_stub
-		SceHid_stub
-		SceSysmodule_stub
-		SceTouch_stub
-		SceMotion_stub
-	)
 	vita_create_self(freegemas.self freegemas)
 
 	vita_create_vpk(freegemas.vpk ${VITA_TITLEID} freegemas.self
@@ -122,96 +117,8 @@ if (VITA)
 		    FILE media media
 	)
 ELSEIF(WIN32)
-	option(BUILD_STATIC "Build a static binary (Windows only)" OFF)
-
-	find_package(SDL2 CONFIG REQUIRED)
-	find_package(sdl2-image CONFIG REQUIRED)
-	find_package(sdl2-ttf CONFIG REQUIRED)
-	find_package(sdl2-mixer CONFIG REQUIRED)
-	find_package(jsoncpp CONFIG REQUIRED)
-
-	target_link_libraries(freegemas PRIVATE
-		SDL2::SDL2
-		SDL2::SDL2main
-		SDL2::SDL2_image
-		SDL2::SDL2_ttf
-		SDL2::SDL2_mixer
-		jsoncpp_object
-		JsonCpp::JsonCpp
-	)
-
-	target_include_directories(freegemas PRIVATE
-		${PROJECT_SOURCE_DIR}/include
-
-		${SDL2_INCLUDE_DIRS}
-		${SDL2_IMAGE_INCLUDE_DIRS}
-		${SDL2_TTF_INCLUDE_DIRS}
-		${SDL2_MIXER_INCLUDE_DIRS}
-		${JSONCPP_INCLUDE_DIRS}
-	)
-
-	if(BUILD_STATIC)
-		if(MSVC)
-			set(CompilerFlags
-				CMAKE_CXX_FLAGS
-				CMAKE_CXX_FLAGS_DEBUG
-				CMAKE_CXX_FLAGS_RELEASE
-				CMAKE_CXX_FLAGS_MINSIZEREL
-				CMAKE_CXX_FLAGS_RELWITHDEBINFO
-			)
-			foreach(CompilerFlag ${CompilerFlags})
-				string(REPLACE "/MD" "/MT" ${CompilerFlag} "${${CompilerFlag}}")
-				set(${CompilerFlag} "${${CompilerFlag}}" CACHE STRING "msvc compiler flags" FORCE)
-				message("MSVC flags: ${CompilerFlag}:${${CompilerFlag}}")
-			endforeach()
-		endif()
-
-		target_link_libraries(freegemas PRIVATE
-			SDL2::SDL2-static
-			jsoncpp_static
-			vorbis
-			ogg
-			Shlwapi
-		)
-	endif()
+	# Nothing to do
 ELSE()
-	find_package(PkgConfig REQUIRED)
-
-	find_package(SDL2 REQUIRED)
-	pkg_search_module(SDL2IMAGE REQUIRED SDL2_image>=2.0.0)
-	pkg_search_module(SDL2TTF REQUIRED SDL2_ttf>=2.0.0)
-	pkg_search_module(SDL2MIXER REQUIRED SDL2_mixer>=2.0.0)
-	pkg_search_module(JSONCPP REQUIRED jsoncpp)
-
-	include_directories(
-		${PROJECT_SOURCE_DIR}/include
-		${SDL2_INCLUDE_DIRS}
-		${SDL2IMAGE_INCLUDE_DIRS}
-		${SDL2TTF_INCLUDE_DIRS}
-		${SDL2MIXER_INCLUDE_DIRS}
-		${LIBINTL_INCLUDE_DIRS}
-		${JSONCPP_INCLUDE_DIRS}
-	)
-
-	target_link_libraries(freegemas
-	${SDL2_LIBRARIES}
-	${SDL2IMAGE_LIBRARIES}
-	${SDL2TTF_LIBRARIES}
-	${SDL2MIXER_LIBRARIES}
-	${LIBINTL_LIBRARIES}
-	${JSONCPP_LIBRARIES}
-	)
-
-	add_custom_target(
-		link_media_folder
-		COMMAND ln -nfs ${PROJECT_SOURCE_DIR}/media ${PROJECT_BINARY_DIR}/media
-	)
-
-	add_dependencies(
-		freegemas
-		link_media_folder
-	)
-
 	install(TARGETS freegemas DESTINATION bin)
 	install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/media DESTINATION share/freegemas)
 	install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/platform/unix/freegemas.desktop DESTINATION share/applications)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,7 +66,6 @@ if(BUILD_STATIC)
         ${SDL2_TTF_STATIC_LIBRARIES}
         ${JSONCPP_STATIC_LIBRARIES}
     )
-	if
 else()
     target_link_libraries(freegemas PRIVATE
         ${SDL2_LIBRARIES}

--- a/include/inter.h
+++ b/include/inter.h
@@ -1,12 +1,6 @@
 #ifndef _INTER_H_
 #define _INTER_H_
 
-#if defined(__vita__) || defined(_WIN32)
  #define _(x) x
-#else
- #include <libintl.h>
- #include <locale.h>
- #define _(x) gettext(x)
-#endif
 
 #endif /* _INTER_H_ */

--- a/include/inter.h
+++ b/include/inter.h
@@ -1,7 +1,7 @@
 #ifndef _INTER_H_
 #define _INTER_H_
 
-#if defined(__vita__) || defined(_WIN32)
+#if defined(__vita__) || defined(_WIN32) || defined(__APPLE__)
  #define _(x) x
 #else
  #include <libintl.h>

--- a/include/inter.h
+++ b/include/inter.h
@@ -1,7 +1,7 @@
 #ifndef _INTER_H_
 #define _INTER_H_
 
-#if defined(__vita__) || defined(_WIN32) || defined(__APPLE__)
+#if defined(__vita__) || defined(_WIN32)
  #define _(x) x
 #else
  #include <libintl.h>

--- a/include/inter.h
+++ b/include/inter.h
@@ -1,6 +1,12 @@
 #ifndef _INTER_H_
 #define _INTER_H_
 
+#if defined(__vita__) || defined(_WIN32)
  #define _(x) x
+#else
+ #include <libintl.h>
+ #include <locale.h>
+ #define _(x) gettext(x)
+#endif
 
 #endif /* _INTER_H_ */

--- a/include/inter.h
+++ b/include/inter.h
@@ -1,7 +1,7 @@
 #ifndef _INTER_H_
 #define _INTER_H_
 
-#if defined(__vita__) || defined(WIN32)
+#if defined(__vita__) || defined(_WIN32)
  #define _(x) x
 #else
  #include <libintl.h>

--- a/src/ScoreTable.cpp
+++ b/src/ScoreTable.cpp
@@ -7,7 +7,7 @@
 
 #include <fstream>
 
-#ifdef WIN32
+#ifdef _WIN32
     #include <io.h>
     #include <process.h>
 #else

--- a/src/Util.cpp
+++ b/src/Util.cpp
@@ -3,7 +3,7 @@
 #include <cstdlib>
 #include <SDL.h>
 
-#if !defined(WIN32) && !defined(__vita__)
+#if !defined(_WIN32) && !defined(__vita__)
     #include <dirent.h>
 #endif
 
@@ -18,7 +18,7 @@ std::string getBasePath()
         SDL_free(basePath);
     }
 
-    #if !defined(WIN32) && !defined(__vita__)
+    #if !defined(_WIN32) && !defined(__vita__)
         // Check if game is installed system wide
         DIR* dir = opendir(std::string(basePathStr + "../share/freegemas/").c_str());
         if (dir) {


### PR DESCRIPTION
This includes the following changes:
- Build the Windows version with MSYS2. This is faster and more reliable.
- Drop translation support. It was not used and caused build issues for MacOS.
- Clean up the `CMakeLists.txt` file
- Use a different container to build the Vita build
- Resolve deprecation warnings in Github Actions

@JoseTomasTocino, you might want to take a look at this one. I'm not sure if you'd approve of the translation support change.

I will squash this  when merging.